### PR TITLE
don't use deprecated Objects.toStringHelper method from guava library

### DIFF
--- a/src/krasa/visualvm/runner/VisualVMGenericDebuggerRunnerSettings.java
+++ b/src/krasa/visualvm/runner/VisualVMGenericDebuggerRunnerSettings.java
@@ -1,6 +1,6 @@
 package krasa.visualvm.runner;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.intellij.debugger.impl.GenericDebuggerRunnerSettings;
 import krasa.visualvm.VisualVMHelper;
 
@@ -25,7 +25,7 @@ public class VisualVMGenericDebuggerRunnerSettings extends GenericDebuggerRunner
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this)
+		return MoreObjects.toStringHelper(this)
 				.add("visualVMId", visualVMId)
 				.toString();
 	}


### PR DESCRIPTION
Objects.toStringHelper method was deprecated in Guava long time ago and it's even removed from modern Guava versions. This change is needed to avoid compatibility problems with IntelliJ IDEA 2018.1 where a new version of Guava is bundled.