### PR TITLE
FIX - Java functionality extracted as a plugin

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -70,5 +70,6 @@
 		<applicationConfigurable instance="krasa.visualvm.MyConfigurable" id="VisualVMLauncher" displayName="VisualVM Launcher" />
 	</extensions>
 
+	<depends>com.intellij.modules.java</depends>
 
 </idea-plugin>


### PR DESCRIPTION
I couldn't build the plugin under Intellij 2019.2 and the problem was that the java-api was extracted into its own plugin starting from version 2019.2 .

I updated the plugin.xml according to these posts:
https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin/?_ga=2.207988498.100650904.1565937954-1727925073.1563296670
https://intellij-support.jetbrains.com/hc/en-us/community/posts/360004978640-java-lang-NoClassDefFoundError-in-test-after-upgrading-on-2019-2


Also, to build the plugin, you need to manually add the jars under **{intellij-root}/plugins/java/**. For more help, see this:
https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
