### PR TITLE
#44: Fix executor start action texts

### DIFF
--- a/src/main/java/krasa/visualvm/executor/DebugVisualVMExecutor.java
+++ b/src/main/java/krasa/visualvm/executor/DebugVisualVMExecutor.java
@@ -2,14 +2,13 @@ package krasa.visualvm.executor;
 
 import javax.swing.*;
 
+import com.intellij.execution.executors.DefaultDebugExecutor;
 import krasa.visualvm.Resources;
 
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
-import com.intellij.execution.executors.DefaultRunExecutor;
-
-public class DebugVisualVMExecutor extends DefaultRunExecutor {
+public class DebugVisualVMExecutor extends DefaultDebugExecutor {
 	@NonNls
 	public static final String EXECUTOR_ID = "Debug with VisualVM";
 	public static final String DEBUG_WITH_VISUAL_VM = "DebugWithVisualVM";
@@ -49,6 +48,11 @@ public class DebugVisualVMExecutor extends DefaultRunExecutor {
 	@NotNull
 	public String getStartActionText() {
 		return EXECUTOR_ID;
+	}
+
+	@Override
+	public @NotNull String getStartActionText(@NotNull String configurationName) {
+		return getStartActionText();
 	}
 
 	public String getContextActionId() {

--- a/src/main/java/krasa/visualvm/executor/RunVisualVMExecutor.java
+++ b/src/main/java/krasa/visualvm/executor/RunVisualVMExecutor.java
@@ -50,6 +50,11 @@ public class RunVisualVMExecutor extends DefaultRunExecutor {
 		return RUN_WITH_VISUAL_VM;
 	}
 
+	@Override
+	public @NotNull String getStartActionText(@NotNull String configurationName) {
+		return getStartActionText();
+	}
+
 	public String getContextActionId() {
 		// HACK: ExecutorRegistryImpl expects this to be non-null, but we don't want any context actions for every file
 		return getId() + " context-action-does-not-exist";


### PR DESCRIPTION
The start action texts both incorrectly displayed `Run '<>'`.
This was due to `getStartActionText` not having been overridden in the executors.

Fixed by overriding the appropriate methods and changed `DebugVisualVMExecutor` to extend `DefaultDebugExecutor`.